### PR TITLE
Homepage with version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: main
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+springBoot {
+    buildInfo()
+}
+
 tasks.named('test') {
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/src/main/java/at/gammastrahlung/monopoly_server/network/Homepage.java
+++ b/src/main/java/at/gammastrahlung/monopoly_server/network/Homepage.java
@@ -1,0 +1,49 @@
+package at.gammastrahlung.monopoly_server.network;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Controller
+@RequestMapping("/")
+public class Homepage {
+
+    @Autowired
+    private BuildProperties buildProperties;
+
+    @GetMapping(value = "/", produces = MediaType.TEXT_HTML_VALUE)
+    @ResponseBody
+    public String index(TimeZone timezone) {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                .RFC_1123_DATE_TIME
+                .withZone(timezone.toZoneId()); // Display in caller timezone
+
+        return """
+                <html>
+                    <head>
+                        <title>GammaStrahlung Monopoly Server - %s</title>
+                    </head>
+                    <body>
+                        <h1>GammaStrahlung Monopoly Server</h1>
+                        <a href="https://github.com/gammaStrahlung/monopoly_server"><h4>Visit the GitHub repository</h4></a>
+                        <div>
+                            Built: %s <br>
+                            %s.%s - <a href="https://github.com/gammaStrahlung/monopoly_server/releases/tag/%s">%s</a>
+                        </div>
+                    </body>
+                </html>
+                """
+                .formatted(buildProperties.getVersion(), // Title
+                        dateTimeFormatter.format(buildProperties.getTime()), // Build time
+                        buildProperties.getGroup(), buildProperties.getArtifact(), // at.gammastrahlung.monopoly_server
+                        buildProperties.getVersion(), // vX.X.X for github release link
+                        buildProperties.getVersion()); // vX.X.X displayed in page
+    }
+}


### PR DESCRIPTION
Adds a simple homepage that displays the built version to much more easily see which version is currently running on the server.

From this:
![image](https://github.com/gammaStrahlung/monopoly_server/assets/56844505/8985c6f4-fa5a-40fc-95d9-61f08357a66c)

To this:
![image](https://github.com/gammaStrahlung/monopoly_server/assets/56844505/b44730f0-a6e4-45cb-9d02-225d62d3bed7)
